### PR TITLE
Update to Publication Checklist 0.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "require": {
         "php": ">=7.1",
         "humanmade/workflows": "~0.3.4",
-        "humanmade/publication-checklist": "~0.1.0"
+        "humanmade/publication-checklist": "~0.2.0"
     },
     "license": "GPL-3.0",
     "authors": [

--- a/docs/publication-checklist.md
+++ b/docs/publication-checklist.md
@@ -53,7 +53,7 @@ use Altis\Workflow\PublicationChecklist\Status;
 
 add_action( 'altis.publication-checklist.register_prepublish_checks', function () {
 	register_prepublish_check( 'foo', [
-		'run_check' => function ( array $post, array $meta ) : Status {
+		'run_check' => function ( array $post, array $meta, array $terms ) : Status {
 			if ( isset( $meta['foo'] ) ) {
 				return new Status( Status::COMPLETE, 'Foo completed' );
 			}
@@ -69,12 +69,34 @@ Checks are registered via the `Altis\Workflow\PublicationChecklist\register_prep
 Your check function receives the post data as an array, and the post's meta data as an array. Your function should only use this data to run the check, as this may represent data before it is saved to the database. Specifically, your function's signature should be:
 
 ```php
-function ( array $post, array $meta ) : Status;
+function ( array $post, array $meta, array $terms ) : Status;
 ```
 
 Your function must return a `Altis\Workflow\PublicationChecklist\Status` object. This object is marked as either complete (allow publishing), incomplete (block publishing), or informational (show as failed, but allow publishing). This status object takes the status type (which should be either `Status::COMPLETE`, `Status::INCOMPLETE`, or `Status::INFO`) and a human-readable message.
 
+`$post` is an array of post data, matching the shape returned by `get_post( $id, ARRAY_A )`. `$meta` is an array of meta data, in the format `string $key => mixed|mixed[] $value`. `$terms` is an array of terms, in the format `string $taxonomy => int[] $terms`.
+
 You can additionally pass data with the status object, which can be used on the frontend to assist with rendering.
+
+By default, checks will only run against the `post` post type. You can pass the relevant type(s) as a `type` option:
+
+```php
+add_action( 'altis.publication-checklist.register_prepublish_checks', function () {
+	// Pass a single type:
+	register_prepublish_check( 'foo', [
+		'type' => 'page',
+		// ...
+	] );
+
+	// Or multiple:
+	register_prepublish_check( 'foo', [
+		'type' => [
+			'post',
+			'page',
+		],
+		// ...
+	] );
+```
 
 
 ## Displaying check status


### PR DESCRIPTION
Adds support custom types (https://github.com/humanmade/publication-checklist/pull/10) and passes terms to checks too (https://github.com/humanmade/publication-checklist/pull/11).

Likely needs docs updates too.

