### PR TITLE
Fix notifications namespace loading

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
     ],
     "autoload": {
         "files": [
-            "inc/namespace.php"
+            "inc/namespace.php",
+            "inc/notifications/namespace.php"
         ]
     },
     "extra": {

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -15,7 +15,7 @@ use Altis;
  * @return void
  */
 function bootstrap() {
-	add_action( 'muplugins_loaded', __NAMESPACE__ . '\\load_workflows', 0 );
+	add_action( 'muplugins_loaded', __NAMESPACE__ . '\\load_notifications', 0 );
 	add_action( 'muplugins_loaded', __NAMESPACE__ . '\\load_publication_checklist', 0 );
 }
 
@@ -24,12 +24,8 @@ function bootstrap() {
  *
  * @return void
  */
-function load_workflows() {
-	$config = Altis\get_config()['modules']['workflow']['notifications'] ?? null;
-	if ( ! $config ) {
-		return;
-	}
-	require_once Altis\ROOT_DIR . '/vendor/humanmade/workflows/plugin.php';
+function load_notifications() {
+	Notifications\setup();
 }
 
 /**

--- a/inc/notifications/namespace.php
+++ b/inc/notifications/namespace.php
@@ -14,27 +14,33 @@ use HM\Workflows\Workflow;
  * Interpret configuration and set up hooks.
  */
 function setup() {
-	$config = Altis\get_config()['modules']['workflow'];
+	$config = Altis\get_config()['modules']['workflow']['notifications'] ?? null;
 
-	if ( ! $config['notifications'] ) {
+	if ( ! is_array( $config ) && ! $config ) {
 		return;
 	}
 
-	if ( $config['notifications']['on-post-published'] ) {
+	if ( ! is_array( $config ) ) {
+		$config = [];
+	}
+
+	if ( $config['on-post-published'] ?? false ) {
 		add_action( 'hm.workflows.init', __NAMESPACE__ . '\\on_post_published' );
 	}
 
-	if ( $config['notifications']['on-submit-for-review'] ) {
+	if ( $config['on-submit-for-review'] ?? false ) {
 		add_action( 'hm.workflows.init', __NAMESPACE__ . '\\on_submit_for_review' );
 	}
 
-	if ( $config['notifications']['on-update-assignees'] ) {
+	if ( $config['on-update-assignees'] ?? false ) {
 		add_action( 'hm.workflows.init', __NAMESPACE__ . '\\on_update_assignees' );
 	}
 
-	if ( $config['notifications']['on-editorial-comment'] ) {
+	if ( $config['on-editorial-comment'] ?? false ) {
 		add_action( 'hm.workflows.init', __NAMESPACE__ . '\\on_editorial_comment' );
 	}
+
+	require_once Altis\ROOT_DIR . '/vendor/humanmade/workflows/plugin.php';
 }
 
 /**


### PR DESCRIPTION
The namespace was omitted from the composer.json autoload files section. This update fixes the bug and makes the naming consistent.

Fixes #33