### PR TITLE
Duplicate post xb integration

### DIFF
--- a/docs/clone-and-republish.md
+++ b/docs/clone-and-republish.md
@@ -107,18 +107,22 @@ In the above example, Categories and Tags are excluded from cloned posts, meanin
 
 #### `duplicate_post_excludelist_filter`
 
-Allows you to exclude specific meta fields from duplicated posts.
+Allows you to exclude specific meta fields from duplicated posts. Values passed into the `$meta_excludelist` array can contain wildcards.
+
+Internally in the Duplicate Post plugin, the array is converted into a regular expression string where the `*` character is recognized as wildcard, before being turned back into an array and processed. This means that if you wanted to exclude all meta keys resembling `_my_awesome_meta_*`, you can pass that in and matching keys will be excluded as well (e.g. `_my_awesome_meta_key`, `_my_awesome_meta_value`, `_my_awesome_meta_1`).
 
 **Parameters**
 
-**`$meta_excludelist` _(array)_ The default exclusion list.
+**`$meta_excludelist`** _(array)_ The default exclusion list.
 
 **Example:**
 ```php
 add_filter( 'duplicate_post_excludelist_filter', function( array $meta_excludelist ) {
-	// Add custom fields to the defaults array.
-	$meta_excludelist[] = 'my_custom_field_1';
-	$meta_excludelist[] = 'my_custom_field_2';
+	// Add all custom fields matching "my_custom_field_" to the excluded array.
+	$meta_excludelist[] = 'my_custom_field_*';
+
+	// Exclude a different, specific meta key.
+	$meta_excludelist[] = '_another_custom_meta';
 
 	return $meta_excludelist;
 } );

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -220,6 +220,10 @@ function duplicate_post_update_xb_client_ids( int $new_post_id, WP_Post $post ) 
 	// Update the post content.
 	$new_post = get_post( $new_post_id );
 	$new_post->post_content = $updated_post_content;
-	add_post_meta( $new_post_id, '_altis_xb_clientId_updated', true );
-	wp_update_post( $new_post );
+	$updated = wp_update_post( $new_post );
+
+	// Don't add the post meta if we've errored.
+	if ( ! is_wp_error( $updated ) ) {
+		add_post_meta( $new_post_id, '_altis_xb_clientId_updated', true );
+	}
 }

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -179,10 +179,8 @@ function exclude_meta_keys( array $meta_excludelist ) : array {
 /**
  * Update XB client IDs when duplicating a post.
  *
- * @param array $new_post The duplicated post data.
+ * @param array $new_post_ID The duplicated post ID.
  * @param WP_Post $post The original WP_Post object.
- *
- * @return array The filtered duplicate post content.
  */
 function duplicate_post_update_xb_client_ids( int $new_post_id, WP_Post $post ) {
 	// Bail if we aren't on a post type supported by Duplicate Posts.

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -21,6 +21,7 @@ function bootstrap() {
 	add_action( 'muplugins_loaded', __NAMESPACE__ . '\\load_duplicate_posts' );
 	add_action( 'admin_menu', __NAMESPACE__ . '\\remove_duplicate_post_admin_page', 99 );
 	add_action( 'admin_init', __NAMESPACE__ . '\\filter_duplicate_post_columns', 1000 );
+	add_action( 'duplicate_post_post_copy', __NAMESPACE__ . '\\duplicate_post_update_xb_client_ids', 10, 2 );
 	add_filter( 'duplicate_post_enabled_post_types', __NAMESPACE__ . '\\set_enabled_post_types' );
 	add_filter( 'pre_option_duplicate_post_roles', __NAMESPACE__ . '\\filter_duplicate_post_roles' );
 	add_filter( 'pre_option_duplicate_post_taxonomies_blacklist', __NAMESPACE__ . '\\filter_duplicate_post_excluded_taxonomies' );

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -8,6 +8,7 @@
 namespace Altis\Workflow;
 
 use Altis;
+use WP_Post;
 
 /**
  * Bootstrap Workflow module.

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -23,6 +23,7 @@ function bootstrap() {
 	add_filter( 'duplicate_post_enabled_post_types', __NAMESPACE__ . '\\set_enabled_post_types' );
 	add_filter( 'pre_option_duplicate_post_roles', __NAMESPACE__ . '\\filter_duplicate_post_roles' );
 	add_filter( 'pre_option_duplicate_post_taxonomies_blacklist', __NAMESPACE__ . '\\filter_duplicate_post_excluded_taxonomies' );
+	add_filter( 'duplicate_post_excludelist_filter', __NAMESPACE__ . '\\exclude_ab_test_meta_keys' );
 }
 
 /**
@@ -157,4 +158,17 @@ function filter_duplicate_post_excluded_taxonomies( $taxonomies ) : array {
  */
 function get_duplicate_post_types() : array {
 	return apply_filters( 'duplicate_post_enabled_post_types', [] );
+}
+
+/**
+ * Exclude Altis A/B Test meta data from duplicated posts.
+ *
+ * @param array $meta_excludelist The meta exclude list from the Duplicate Post options.
+ *
+ * @return array The filtered exclude list array.
+ */
+function exclude_ab_test_meta_keys( array $meta_excludelist ) : array {
+	$meta_excludelist[] = '_altis_ab_test_*';
+
+	return $meta_excludelist;
 }

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -179,7 +179,7 @@ function exclude_meta_keys( array $meta_excludelist ) : array {
 /**
  * Update XB client IDs when duplicating a post.
  *
- * @param array $new_post_ID The duplicated post ID.
+ * @param int $new_post_id The duplicated post ID.
  * @param WP_Post $post The original WP_Post object.
  */
 function duplicate_post_update_xb_client_ids( int $new_post_id, WP_Post $post ) {

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -23,7 +23,7 @@ function bootstrap() {
 	add_filter( 'duplicate_post_enabled_post_types', __NAMESPACE__ . '\\set_enabled_post_types' );
 	add_filter( 'pre_option_duplicate_post_roles', __NAMESPACE__ . '\\filter_duplicate_post_roles' );
 	add_filter( 'pre_option_duplicate_post_taxonomies_blacklist', __NAMESPACE__ . '\\filter_duplicate_post_excluded_taxonomies' );
-	add_filter( 'duplicate_post_excludelist_filter', __NAMESPACE__ . '\\exclude_ab_test_meta_keys' );
+	add_filter( 'duplicate_post_excludelist_filter', __NAMESPACE__ . '\\exclude_meta_keys' );
 	add_filter( 'duplicate_post_new_post', __NAMESPACE__ . '\\duplicate_post_update_xb_client_ids' );
 }
 
@@ -168,8 +168,9 @@ function get_duplicate_post_types() : array {
  *
  * @return array The filtered exclude list array.
  */
-function exclude_ab_test_meta_keys( array $meta_excludelist ) : array {
+function exclude_meta_keys( array $meta_excludelist ) : array {
 	$meta_excludelist[] = '_altis_ab_test_*';
+	$meta_excludelist[] = '_altis_xb_clientId_updated';
 
 	return $meta_excludelist;
 }

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -24,6 +24,7 @@ function bootstrap() {
 	add_filter( 'pre_option_duplicate_post_roles', __NAMESPACE__ . '\\filter_duplicate_post_roles' );
 	add_filter( 'pre_option_duplicate_post_taxonomies_blacklist', __NAMESPACE__ . '\\filter_duplicate_post_excluded_taxonomies' );
 	add_filter( 'duplicate_post_excludelist_filter', __NAMESPACE__ . '\\exclude_ab_test_meta_keys' );
+	add_filter( 'duplicate_post_new_post', __NAMESPACE__ . '\\duplicate_post_update_xb_client_ids' );
 }
 
 /**
@@ -171,4 +172,23 @@ function exclude_ab_test_meta_keys( array $meta_excludelist ) : array {
 	$meta_excludelist[] = '_altis_ab_test_*';
 
 	return $meta_excludelist;
+}
+
+/**
+ * Update XB client IDs when duplicating a post.
+ *
+ * @param array $post The duplicated post data.
+ *
+ * @return array The filtered duplicate post content.
+ */
+function duplicate_post_update_xb_client_ids( array $post ) : array {
+	$post['post_content'] = preg_replace_callback(
+		'#<!-- wp:altis/(personalization|experiment)\s+{.*?"clientId":"([a-z0-9-]+)"#',
+		function ( array $matches ) : string {
+			return str_replace( $matches[2], wp_generate_uuid4(), $matches[0] );
+		},
+		$post['post_content']
+	);
+
+	return $post;
 }

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -207,7 +207,6 @@ function duplicate_post_update_xb_client_ids( int $new_post_id, WP_Post $post ) 
 		return;
 	}
 
-	$post_content = $post->post_content;
 	$pattern = '#<!-- wp:altis/(personalization|experiment)\s+{.*?"clientId":"([a-z0-9-]+)"#';
 
 	$updated_post_content = preg_replace_callback(
@@ -215,7 +214,7 @@ function duplicate_post_update_xb_client_ids( int $new_post_id, WP_Post $post ) 
 		function ( array $matches ) : string {
 			return str_replace( $matches[2], wp_generate_uuid4(), $matches[0] );
 		},
-		$post_content
+		$post->post_content
 	);
 
 	// Update the post content.


### PR DESCRIPTION
fixes #67 

This PR adds two Duplicate Post filters that perform the same duties as the Post Cloner filters in the Analytics module.

This also updates the Duplicate Post documentation for the meta key exclusion filter which actually takes wildcards, making the regex matching used in the Post Cloner filter unnecessary (but this isn't documented in the dev docs for Duplicate Posts).

* [x] remove the filters from Analytics. https://github.com/humanmade/altis-analytics/pull/154
