### PR TITLE
Fix warning on block widgets screen

### DIFF
--- a/inc/clone-amend/namespace.php
+++ b/inc/clone-amend/namespace.php
@@ -417,6 +417,10 @@ function replace_amended_post_notice() {
 	$rewriting = ! empty( $_REQUEST['rewriting'] ); // phpcs:ignore WordPress.Security.NonceVerification
 	$republished = ! empty( $_REQUEST['dprepublished'] ); // phpcs:ignore WordPress.Security.NonceVerification
 	$post = get_post();
+	if ( empty( $post ) ) {
+		return;
+	}
+
 	$duplicated = ! empty( get_post_meta( $post->ID, '_dp_has_rewrite_republish_copy', true ) );
 
 	// Bail if not rewriting/amending a post.


### PR DESCRIPTION
The post object is not defined on the widget editing screen when the `replace_amended_post_notice` callback runs on the `enqueue_block_editor_assets` hook.