### PR TITLE
Remove product from public post types if WooCommerce is active.

### DIFF
--- a/inc/clone-amend/namespace.php
+++ b/inc/clone-amend/namespace.php
@@ -56,6 +56,11 @@ function set_enabled_post_types( array $enabled_post_types ) : array {
 	$public_post_types = get_post_types( [ 'public' => true ], 'names' );
 	$post_types = Altis\get_config()['modules']['workflow']['clone-amend']['post-types'] ?? null;
 
+	// If WooCommerce exsists, unset the post type Product.
+	if ( class_exists( 'woocommerce' ) ) {
+		unset( $public_post_types['product'] );
+	}
+
 	if ( ! $post_types ) {
 		return $public_post_types;
 	}

--- a/inc/clone-amend/namespace.php
+++ b/inc/clone-amend/namespace.php
@@ -57,7 +57,7 @@ function set_enabled_post_types( array $enabled_post_types ) : array {
 	$post_types = Altis\get_config()['modules']['workflow']['clone-amend']['post-types'] ?? null;
 
 	// If WooCommerce exsists, unset the post type Product.
-	if ( class_exists( 'woocommerce' ) ) {
+	if ( class_exists( 'WooCommerce' ) ) {
 		unset( $public_post_types['product'] );
 	}
 


### PR DESCRIPTION
Related issue : https://github.com/humanmade/altis-workflow/issues/158

This PR adds a check to see if `woocommerce` class exists and then unsets `product` from the `$public_post_types`.

#### Screenshots
Creating a new product ( before / after )

![Screenshot 2022-08-01 at 11 34 15](https://user-images.githubusercontent.com/16571365/182120196-5d691b5d-e86c-4427-a5ad-cda30e6746c0.png)![Screenshot 2022-08-01 at 11 34 47](https://user-images.githubusercontent.com/16571365/182120305-8af6376e-4cfc-486d-b1e6-eedafa7ed1af.png)

Editing a product ( before / after )
![Screenshot 2022-08-01 at 11 36 45](https://user-images.githubusercontent.com/16571365/182120223-26fc62bf-51a6-4196-b8e0-bb841cdf2044.png)![Screenshot 2022-08-01 at 11 37 20](https://user-images.githubusercontent.com/16571365/182120315-6deaf19f-9110-4638-b42a-f6c9b66f88fa.png)




