### PR TITLE
Guard against PHP warning when using QM logged out

### DIFF
--- a/inc/notifications/class-qm-collector-notifications.php
+++ b/inc/notifications/class-qm-collector-notifications.php
@@ -27,6 +27,12 @@ class QM_Collector_Notifications extends QM_Collector {
 	public function process() {
 		$this->data['notifications'] = [];
 		$user_id = get_current_user_id();
+
+		if ( empty( $user_id ) ) {
+			// QM can be used when logged out with an authentication cookie.
+			return;
+		}
+
 		$notifications = get_user_meta( $user_id, 'hm.workflows.notification', false );
 		foreach ( $notifications as $notification_json ) {
 			$notification = json_decode( $notification_json, true );


### PR DESCRIPTION
When using QM on an Altis site with an authentication cookie, this error is observed:

```
PHP Warning:  foreach() argument must be of type array|object, bool given in /usr/src/app/vendor/altis/workflow/inc/notifications/class-qm-collector-notifications.php on line 32
```

In this circumstance there is no user, so "false" is returned from the user meta check.