### PR TITLE
Update yoast/duplicate-post dependency to ~4.6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,10 +3,10 @@
     "description": "Workflow module for Altis",
     "type": "package",
     "require": {
-        "php": ">=7.1",
+        "php": ">=7.4",
         "humanmade/workflows": "~0.4.10",
         "humanmade/publication-checklist": "~0.4.8",
-        "yoast/duplicate-post": "~4.1.2"
+        "yoast/duplicate-post": "~4.6.0"
     },
     "license": "GPL-3.0",
     "authors": [


### PR DESCRIPTION
## Summary
- Bump `yoast/duplicate-post` from `~4.1.2` to `~4.6.0` to patch the
  "Arbitrary Post Duplication and Overwrite" security advisory
  (affected: < 4.6, fixed in: 4.6).
- Bump the module's PHP constraint from `>=7.1` to `>=7.4` to match
  Yoast 4.6's `^7.4 || ^8.0` requirement.

## Runtime note
Yoast 4.6 raises the minimum WordPress version to 6.8. This is a
plugin-level runtime check, not enforced by Composer — sites on
older WordPress may see an activation warning.